### PR TITLE
All all IUPAC codes

### DIFF
--- a/blockjoin.c
+++ b/blockjoin.c
@@ -95,15 +95,18 @@ const unsigned char md_op_table[256]={
     // 0-9 gives 0
     // ^ gives 1
     // ATCGatcgUuNn gives 2 (allow N base since it is the reference)
+    // BDHKMRSVWYbdhkmrsvwy gives 2 too (IUPAC ambiguity codes; the MD char is only
+    // ever used to classify the position as a mismatch, the mismatch base pushed
+    // to buf always comes from the read, never from md_s[i])
     // else: 4
     4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
     4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
     4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
     0, 0, 0, 0,  0, 0, 0, 0,  0, 0, 4, 4,  4, 4, 4, 4,
-    4, 2, 4, 2,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 2/*N*/, 4,
-    4, 4, 4, 4,  2, 2, 4, 4,  4, 4, 4, 4,  4, 4, 1, 4,
-    4, 2, 4, 2,  4, 4, 4, 2,  4, 4, 4, 4,  4, 4, 2/*n*/, 4,
-    4, 4, 4, 4,  2, 2, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
+    4, 2, 2, 2,  2, 4, 4, 2,  2, 4, 4, 2,  4, 2, 2/*N*/, 4,
+    4, 4, 2, 2,  2, 2, 2, 2,  4, 2, 4, 4,  4, 4, 1, 4,
+    4, 2, 2, 2,  2, 4, 4, 2,  2, 4, 4, 2,  4, 2, 2/*n*/, 4,
+    4, 4, 2, 2,  2, 2, 2, 2,  4, 2, 4, 4,  4, 4, 4, 4,
     4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
     4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,
     4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,  4, 4, 4, 4,


### PR DESCRIPTION
Dear Xiaowen,

thanks for making pomfret, it looks very interesting and we are integrating it in our workflow.

I've tested it on a human genome, aligned with the 1KGP reference (GRCh38_full_analysis_set_plus_decoy_hla.fa) "which also uses other IUPAC codes in addition to the canonical ACGTN.

This triggers an error since md_op_table would return 4 for other bases.
I've edited the blockjoin.c source to return 2 also for other IUPAC codes (BDHKMRSVWYbdhkmrsvwy).
My reasoning was that the MD information is only used to classify mismatch, so it should be harmless to return 2 rather than exit completely.

I hope this makes sense, with this fix I was able to run pomfret on our samples.

Best

Francesco